### PR TITLE
fix panic assignment to entry in nil map when set extra-specs

### DIFF
--- a/pkg/rest/compute/v2_1/flavor.go
+++ b/pkg/rest/compute/v2_1/flavor.go
@@ -376,6 +376,11 @@ func (svc *service) FlavorCreateExtraSpecs(c *gin.Context) {
 		return
 	}
 
+	if flavor.Spec.ExtraSpecs == nil {
+		// We want initialize the map in case manifest does
+		// not define any extra-specs property.
+		flavor.Spec.ExtraSpecs = make(map[string]string)
+	}
 	for key, val := range req.ExtraSpecs {
 		flavor.Spec.ExtraSpecs[key] = val
 	}


### PR DESCRIPTION
When extra-specs are not defined in the manifest, the map is not
intialized resulting a panic during property creation. The commit adds
safe-guard to ensure the well initialization of the map.

Signed-off-by: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@redhat.com>