### PR TITLE
adds kubernetes-client package

### DIFF
--- a/docs/devenv-local.md
+++ b/docs/devenv-local.md
@@ -22,6 +22,7 @@ extra software needs installing and configuring
 ```bash
 sudo dnf install etcd docker git libvirt-devel
 sudo dnf install golang glide golang-googlecode-tools-goimports
+sudo dnf install kubernetes-client
 sudo groupadd docker
 sudo gpasswd -a $USER docker
 sudo systemctl enable docker


### PR DESCRIPTION
kubectl is not present on a fresh fedora 26

Signed-off-by: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@redhat.com>