### PR TITLE
prevents flavors creation with name already exists

### DIFF
--- a/pkg/rest/compute/v2_1/flavor.go
+++ b/pkg/rest/compute/v2_1/flavor.go
@@ -307,7 +307,15 @@ func (svc *service) FlavorCreate(c *gin.Context) {
 
 	flavor, err = clnt.Create(flavor)
 	if err != nil {
-		c.AbortWithError(http.StatusInternalServerError, err)
+		if errors.IsAlreadyExists(err) {
+			// It's a design limitation, while OpenStack
+			// Nova accepts flavors with same names. Our
+			// design uses the flavor name as an uniq
+			// identifier.
+			c.AbortWithError(http.StatusConflict, err)
+		} else {
+			c.AbortWithError(http.StatusInternalServerError, err)
+		}
 		return
 	}
 

--- a/pkg/rest/compute/v2_1/flavor.go
+++ b/pkg/rest/compute/v2_1/flavor.go
@@ -282,7 +282,7 @@ func (svc *service) FlavorCreate(c *gin.Context) {
 	}
 
 	if flavor != nil {
-		c.AbortWithError(http.StatusConflict, err)
+		c.AbortWithStatus(http.StatusConflict)
 		return
 	}
 


### PR DESCRIPTION
Even if OpenStack Nova accepts flavors with same names the current
design based on flavor name as uniq identifier can't make that
condition possible.  This commit prevents it and make the process to
return correct a HTTP status code.

Signed-off-by: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@redhat.com>